### PR TITLE
Bugfix/ensure short display group name

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/fergus/service/StorageGridService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/fergus/service/StorageGridService.kt
@@ -32,7 +32,7 @@ import mu.KotlinLogging
 import no.skatteetaten.aurora.fergus.controllers.Access
 import no.skatteetaten.aurora.fergus.controllers.AuthorizationPayload
 import no.skatteetaten.aurora.fergus.error.FergusException
-import no.skatteetaten.aurora.fergus.service.StorageGridConstants.GROUP_DISPLAYNAME_MAXLENGTH
+import no.skatteetaten.aurora.fergus.utils.StorageGridGroupUtils
 
 private val logger = KotlinLogging.logger {}
 
@@ -185,26 +185,7 @@ class StorageGridServiceReactive(
     ): String {
         val groupNamePostfix = createGroupAccessPostfix(access)
 
-        return ensureShortDisplayGroupName(path, bucketName, groupNamePostfix)
-    }
-
-    private fun ensureShortDisplayGroupName(path: String, bucketName: String, groupNamePostfix: String): String {
-        val groupFullPath = "$bucketName-$path-$groupNamePostfix"
-        if (groupFullPath.length <= GROUP_DISPLAYNAME_MAXLENGTH) {
-            return groupFullPath
-        }
-
-        val groupNoPath = "$bucketName-$groupNamePostfix"
-        // Minus 1 because there will be an extra separator added when including shortPath.
-        val pathPartLength = GROUP_DISPLAYNAME_MAXLENGTH - 1 - groupNoPath.length
-        return if (pathPartLength > 0) {
-            val shortPath = path.substring(0, pathPartLength)
-            "$bucketName-$shortPath-$groupNamePostfix"
-        } else if (groupNoPath.length > GROUP_DISPLAYNAME_MAXLENGTH) {
-            groupNoPath.substring(0, GROUP_DISPLAYNAME_MAXLENGTH)
-        } else {
-            groupNoPath
-        }
+        return StorageGridGroupUtils.ensureShortDisplayGroupName(path, bucketName, groupNamePostfix)
     }
 
     private fun createGroupAccessPostfix(access: List<Access>): String {
@@ -424,7 +405,3 @@ data class S3AccessKeys(
     val s3accesskey: String,
     val s3secretaccesskey: String,
 )
-
-object StorageGridConstants {
-    const val GROUP_DISPLAYNAME_MAXLENGTH = 32
-}

--- a/src/main/kotlin/no/skatteetaten/aurora/fergus/utils/StorageGridGroupUtils.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/fergus/utils/StorageGridGroupUtils.kt
@@ -1,0 +1,23 @@
+package no.skatteetaten.aurora.fergus.utils
+
+object StorageGridGroupUtils {
+    const val GROUP_DISPLAYNAME_MAXLENGTH = 32
+    fun ensureShortDisplayGroupName(path: String, bucketName: String, groupNamePostfix: String): String {
+        val groupFullPath = "$bucketName-$path-$groupNamePostfix"
+        if (groupFullPath.length <= GROUP_DISPLAYNAME_MAXLENGTH) {
+            return groupFullPath
+        }
+
+        val groupNoPath = "$bucketName-$groupNamePostfix"
+        // Minus 1 because there will be an extra separator added when including shortPath.
+        val pathPartLength = GROUP_DISPLAYNAME_MAXLENGTH - 1 - groupNoPath.length
+        return if (pathPartLength > 0) {
+            val shortPath = path.substring(0, pathPartLength)
+            "$bucketName-$shortPath-$groupNamePostfix"
+        } else if (groupNoPath.length > GROUP_DISPLAYNAME_MAXLENGTH) {
+            groupNoPath.substring(0, GROUP_DISPLAYNAME_MAXLENGTH)
+        } else {
+            groupNoPath
+        }
+    }
+}

--- a/src/test/kotlin/no/skatteetaten/aurora/fergus/utils/StorageGridGroupUtilsTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/fergus/utils/StorageGridGroupUtilsTest.kt
@@ -1,0 +1,53 @@
+package no.skatteetaten.aurora.fergus.utils
+
+import org.junit.jupiter.api.Test
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isLessThan
+
+class StorageGridGroupUtilsTest {
+    val path = "5e0a376d-b834-44b2-868f-40884d23ee17"
+
+    @Test
+    fun `should generate a groupName with $bucketName-$groupNamePostfix if length is one off max length`() {
+        val bucketName = "aurora-utv-aurora-utvikling"
+        val groupNamePostfix = "RWD"
+        val groupName = StorageGridGroupUtils.ensureShortDisplayGroupName(path, bucketName, groupNamePostfix)
+
+        val expected = "$bucketName-$groupNamePostfix"
+        assertThat(groupName).isEqualTo(expected)
+        assertThat(groupName.length).isEqualTo(31)
+    }
+
+    @Test
+    fun `should generate a groupName with only bucketName since it has displayName max length`() {
+        val bucketName = "aurora-utv-aurora-test-utvikling"
+        val groupNamePostfix = "RWD"
+        val groupName = StorageGridGroupUtils.ensureShortDisplayGroupName(path, bucketName, groupNamePostfix)
+
+        assertThat(bucketName.length).isEqualTo(32)
+        assertThat(groupName).isEqualTo(bucketName)
+        assertThat(groupName.length).isEqualTo(StorageGridGroupUtils.GROUP_DISPLAYNAME_MAXLENGTH)
+    }
+
+    @Test
+    fun `should generate a groupName with bucketName, groupNamePostfix and a part of path`() {
+        val bucketName = "aurora-utv"
+        val groupNamePostfix = "RWD"
+        val groupName = StorageGridGroupUtils.ensureShortDisplayGroupName(path, bucketName, groupNamePostfix)
+
+        assertThat(groupName).isEqualTo("aurora-utv-5e0a376d-b834-44b-RWD")
+        assertThat(groupName.length).isEqualTo(StorageGridGroupUtils.GROUP_DISPLAYNAME_MAXLENGTH)
+    }
+
+    @Test
+    fun `should generate a groupName including bucketName, path and groupNamePostfix`() {
+        val newPath = "abc"
+        val bucketName = "aurora-utv"
+        val groupNamePostfix = "RWD"
+        val groupName = StorageGridGroupUtils.ensureShortDisplayGroupName(newPath, bucketName, groupNamePostfix)
+
+        assertThat(groupName).isEqualTo("aurora-utv-abc-RWD")
+        assertThat(groupName.length).isLessThan(StorageGridGroupUtils.GROUP_DISPLAYNAME_MAXLENGTH)
+    }
+}


### PR DESCRIPTION
Støtte på et problem med ensureShortDisplayGroupName hvis bucketName og groupNamePostfix var **en** mindre enn max length. Fikk da StringIndexOutOfBoundsException.
Trekte ut den koden i et eget objekt og la til tester.