### PR TITLE
AOS-6717 bumping for spring boot 2.6.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("idea")
     id("java")
     id("org.openapi.generator") version "5.2.0"
-    id("no.skatteetaten.gradle.aurora") version("4.4.16")
+    id("no.skatteetaten.gradle.aurora") version("4.4.22")
 }
 
 aurora {


### PR DESCRIPTION
Bumpet aurora gradle plugin, som vil gi riktig spring boot versjon.